### PR TITLE
Bugfix for #125

### DIFF
--- a/MeteorApp/client/components/character/CharacterView.jsx
+++ b/MeteorApp/client/components/character/CharacterView.jsx
@@ -36,7 +36,7 @@ CharacterView = React.createClass({
             }
             else {
                 for(i = 0; i < data.campaigns.length; i++){
-                    if(data.user._id == data.campaigns[i].game_master){
+                    if(data.user.username == data.campaigns[i].game_master_name){
                         data.canEdit = true;
                     }
                 }


### PR DESCRIPTION
There were two fields in campaign, game_master, and game_master_name, and I used game_master when originally setting up the "view no edit" thing, but it turns out that only game_master_name was updated when game master was updated... we really shouldn't have 2 fields that served the same purpose.
